### PR TITLE
fixed out of bounds memory access

### DIFF
--- a/src/sym/macho.c
+++ b/src/sym/macho.c
@@ -110,6 +110,13 @@ macho_objc_info_t *parse_objc_info(FILE *fp) {
     for (int i = 0; i < header->ncmds; i++) {
         if (command->cmd == LC_SEGMENT_64) {
             const struct segment_command_64 *seg_cmd = (void *)command;
+            if (strcmp(seg_cmd->segname, SEG_TEXT) == 0) { /* __TEXT */
+                /* addr_vm - text_vm = addr_file - text_file */
+                macho_info->vm_slide = seg_cmd->fileoff - seg_cmd->vmaddr;
+                /* also include __TEXT in the mapped end */
+                if (dataend < seg_cmd->fileoff + seg_cmd->filesize)
+                    dataend = seg_cmd->fileoff + seg_cmd->filesize;
+            }
             if (strncmp(seg_cmd->segname, "__DATA", 6) == 0) {
                 if (dataend < seg_cmd->fileoff + seg_cmd->filesize)
                     dataend = seg_cmd->fileoff + seg_cmd->filesize;

--- a/src/sym/objcmeta.c
+++ b/src/sym/objcmeta.c
@@ -70,6 +70,7 @@ void seperate_method(const char *symbol_name, char **class_name, char **sel_name
 long solve_objc_symbol(FILE *fp, const macho_objc_info_t *macho_info, const char* symbol_name) {
     uint64_t symbol_address = 0;
     const long base_offset = macho_info->base_offset;
+    const uint64_t vm_slide = macho_info->vm_slide;
 
     if (macho_info->objc_classlist_off == 0) {
         fprintf(stderr, "symp: missing __objc_classlist section!\n");
@@ -81,18 +82,19 @@ long solve_objc_symbol(FILE *fp, const macho_objc_info_t *macho_info, const char
     seperate_method(symbol_name, &sym_cls, &sym_sel);
 
     const void *macho_data = read_file_off(fp, macho_info->dataend_off, base_offset);
+    #define VM_TO_FILE_OFF(vmaddr) ((uint64_t)((vmaddr) & ISA_MASK) + vm_slide)
     const uint64_t *classlist = macho_data + macho_info->objc_classlist_off;
     uint64_t nclasses = macho_info->objc_classlist_size / sizeof(uint64_t);
     for (int i = 0; i < nclasses; i++) {
-        const struct objc_class_t *objc_cls = macho_data + (classlist[i] & ISA_MASK);
+        const struct objc_class_t *objc_cls = macho_data + VM_TO_FILE_OFF(classlist[i]);
         if (sym_type == '+') /* class method are in metaclass */
-            objc_cls = macho_data + (objc_cls->isaVMAddr & ISA_MASK);
-        const struct class_ro_t *class_data = macho_data + (objc_cls->dataVMAddrAndFastFlags & FAST_DATA_MASK);
-        const char *class_name = macho_data + (class_data->nameVMAddr & ISA_MASK);
+            objc_cls = macho_data + VM_TO_FILE_OFF(objc_cls->isaVMAddr);
+        const struct class_ro_t *class_data = macho_data + (VM_TO_FILE_OFF(objc_cls->dataVMAddrAndFastFlags) & FAST_DATA_MASK);
+        const char *class_name = macho_data + VM_TO_FILE_OFF(class_data->nameVMAddr);
         if (strcmp(class_name, sym_cls) != 0)
             continue;
         if ((class_data->baseMethodsVMAddr) != 0) {
-            const struct method_list_t *method_list = macho_data + (class_data->baseMethodsVMAddr & ISA_MASK);
+            const struct method_list_t *method_list = macho_data + VM_TO_FILE_OFF(class_data->baseMethodsVMAddr);
             uint32_t entsize = method_list->entsize & 0x0000FFFC; /* methodListSizeMask */
             const void *cur_method = (void *)(method_list + 1);
             for (int j = 0; j < method_list->count; j++) {
@@ -101,13 +103,13 @@ long solve_objc_symbol(FILE *fp, const macho_objc_info_t *macho_info, const char
                 if ((method_list->entsize & 0x80000000) != 0) { /* usesRelativeOffsets */
                     const struct relative_method_t *rel_method = cur_method;
                     const uint64_t *method_sel = (void *)rel_method + offsetof(struct relative_method_t, nameOffset) + rel_method->nameOffset;
-                    method_name = macho_data + (*method_sel & ISA_MASK);
+                    method_name = macho_data + VM_TO_FILE_OFF(*method_sel);
                     method_imp_off = (uint64_t)rel_method - (uint64_t)macho_data + offsetof(struct relative_method_t, impOffset) + rel_method->impOffset;
                 }
                 else {
                     const struct method_t *method = cur_method;
-                    method_name = macho_data + (method->nameVMAddr & ISA_MASK);
-                    method_imp_off = method->impVMAddr & ISA_MASK;
+                    method_name = macho_data + VM_TO_FILE_OFF(method->nameVMAddr);
+                    method_imp_off = VM_TO_FILE_OFF(method->impVMAddr);
                 }
                 if (strcmp(method_name, sym_sel) == 0) {
                     symbol_address = base_offset + method_imp_off;
@@ -122,5 +124,6 @@ long solve_objc_symbol(FILE *fp, const macho_objc_info_t *macho_info, const char
     free(sym_cls);
     free(sym_sel);
     free((void *)macho_data);
+    #undef VM_TO_FILE_OFF
     return (long)symbol_address;
 }

--- a/src/sym/private.h
+++ b/src/sym/private.h
@@ -43,7 +43,10 @@ typedef struct {
     int32_t cputype;
     long base_offset;
 
-    /* __DATA ending */
+    /* __TEXT vm slide */
+    uint64_t vm_slide;
+
+    /* mapped file end offset we will read up to (covers __TEXT + __DATA*) */
     uint64_t dataend_off;
 
     /* objc sections */


### PR DESCRIPTION
This pull request introduces important changes to how Mach-O Objective-C symbol resolution works, specifically improving the accuracy of address translation between virtual memory and file offsets. The main update is the addition of a `vm_slide` field to the `macho_objc_info_t` struct, and the use of a new macro to consistently translate VM addresses to file offsets throughout the symbol resolution logic.